### PR TITLE
Use Telegram config data from separate config array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,5 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "cs": "php-cs-fixer fix"
-    },
-    "minimum-stability": "dev"
-
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,6 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "cs": "php-cs-fixer fix"
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,7 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "cs": "php-cs-fixer fix"
-    }
+    },
+    "minimum-stability": "dev"
+
 }

--- a/src/TelegramAudioDriver.php
+++ b/src/TelegramAudioDriver.php
@@ -43,7 +43,7 @@ class TelegramAudioDriver extends TelegramDriver
         if ($this->event->has('voice')) {
             $audio = $this->event->get('voice');
         }
-        $response = $this->http->get('https://api.telegram.org/bot'.$this->config->get('telegram_token').'/getFile', [
+        $response = $this->http->get('https://api.telegram.org/bot'.$this->config->get('token').'/getFile', [
             'file_id' => $audio['file_id'],
         ]);
 
@@ -53,7 +53,7 @@ class TelegramAudioDriver extends TelegramDriver
         // This need a proper logging and exception system in the future
         $url = null;
         if (isset($path->result)) {
-            $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
+            $url = 'https://api.telegram.org/file/bot'.$this->config->get('token').'/'.$path->result->file_path;
         }
 
         return [new Audio($url, $audio)];

--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -31,6 +31,7 @@ class TelegramDriver extends HttpDriver
     {
         $this->payload = new ParameterBag((array) json_decode($request->getContent(), true));
         $this->event = Collection::make($this->payload->get('message'));
+        $this->config = Collection::make($this->config->get('telegram'));
     }
 
     /**
@@ -44,7 +45,7 @@ class TelegramDriver extends HttpDriver
             'user_id' => $matchingMessage->getSender(),
         ];
 
-        $response = $this->http->post('https://api.telegram.org/bot'.$this->config->get('telegram_token').'/getChatMember',
+        $response = $this->http->post('https://api.telegram.org/bot'.$this->config->get('token').'/getChatMember',
             [], $parameters);
         $responseData = json_decode($response->getContent(), true);
         $userData = Collection::make($responseData['result']['user']);
@@ -129,7 +130,7 @@ class TelegramDriver extends HttpDriver
             'chat_id' => $matchingMessage->getRecipient(),
             'action' => 'typing',
         ];
-        $this->http->post('https://api.telegram.org/bot'.$this->config->get('telegram_token').'/sendChatAction', [],
+        $result = $this->http->post('https://api.telegram.org/bot'.$this->config->get('token').'/sendChatAction', [],
             $parameters);
     }
 
@@ -169,7 +170,7 @@ class TelegramDriver extends HttpDriver
             'inline_keyboard' => [],
         ];
 
-        return $this->http->post('https://api.telegram.org/bot'.$this->config->get('telegram_token').'/editMessageReplyMarkup',
+        return $this->http->post('https://api.telegram.org/bot'.$this->config->get('token').'/editMessageReplyMarkup',
             [], $parameters);
     }
 
@@ -236,7 +237,7 @@ class TelegramDriver extends HttpDriver
      */
     public function sendPayload($payload)
     {
-        return $this->http->post('https://api.telegram.org/bot'.$this->config->get('telegram_token').'/'.$this->endpoint,
+        return $this->http->post('https://api.telegram.org/bot'.$this->config->get('token').'/'.$this->endpoint,
             [], $payload);
     }
 
@@ -245,7 +246,7 @@ class TelegramDriver extends HttpDriver
      */
     public function isConfigured()
     {
-        return ! empty($this->config->get('telegram_token'));
+        return ! empty($this->config->get('token'));
     }
 
     /**
@@ -262,7 +263,7 @@ class TelegramDriver extends HttpDriver
             'chat_id' => $matchingMessage->getRecipient(),
         ], $parameters);
 
-        return $this->http->post('https://api.telegram.org/bot'.$this->config->get('telegram_token').'/'.$endpoint, [],
+        return $this->http->post('https://api.telegram.org/bot'.$this->config->get('token').'/'.$endpoint, [],
             $parameters);
     }
 }

--- a/src/TelegramFileDriver.php
+++ b/src/TelegramFileDriver.php
@@ -41,7 +41,7 @@ class TelegramFileDriver extends TelegramDriver
     {
         $file = $this->event->get('document');
 
-        $response = $this->http->get('https://api.telegram.org/bot'.$this->config->get('telegram_token').'/getFile', [
+        $response = $this->http->get('https://api.telegram.org/bot'.$this->config->get('token').'/getFile', [
             'file_id' => $file['file_id'],
         ]);
 
@@ -51,7 +51,7 @@ class TelegramFileDriver extends TelegramDriver
         // This need a proper logging and exception system in the future
         $url = null;
         if (isset($path->result)) {
-            $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
+            $url = 'https://api.telegram.org/file/bot'.$this->config->get('token').'/'.$path->result->file_path;
         }
 
         return [new File($url, $file)];

--- a/src/TelegramPhotoDriver.php
+++ b/src/TelegramPhotoDriver.php
@@ -42,7 +42,7 @@ class TelegramPhotoDriver extends TelegramDriver
     {
         $photos = $this->event->get('photo');
         $largetstPhoto = array_pop($photos);
-        $response = $this->http->get('https://api.telegram.org/bot'.$this->config->get('telegram_token').'/getFile', [
+        $response = $this->http->get('https://api.telegram.org/bot'.$this->config->get('token').'/getFile', [
             'file_id' => $largetstPhoto['file_id'],
         ]);
 
@@ -52,7 +52,7 @@ class TelegramPhotoDriver extends TelegramDriver
         // This need a proper logging and exception system in the future
         $url = null;
         if (isset($path->result)) {
-            $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
+            $url = 'https://api.telegram.org/file/bot'.$this->config->get('token').'/'.$path->result->file_path;
         }
 
         return [new Image($url, $largetstPhoto)];

--- a/src/TelegramVideoDriver.php
+++ b/src/TelegramVideoDriver.php
@@ -40,7 +40,7 @@ class TelegramVideoDriver extends TelegramDriver
     private function getVideos()
     {
         $video = $this->event->get('video');
-        $response = $this->http->get('https://api.telegram.org/bot'.$this->config->get('telegram_token').'/getFile', [
+        $response = $this->http->get('https://api.telegram.org/bot'.$this->config->get('token').'/getFile', [
             'file_id' => $video['file_id'],
         ]);
 
@@ -50,7 +50,7 @@ class TelegramVideoDriver extends TelegramDriver
         // This need a proper logging and exception system in the future
         $url = null;
         if (isset($path->result)) {
-            $url = 'https://api.telegram.org/file/bot'.$this->config->get('telegram_token').'/'.$path->result->file_path;
+            $url = 'https://api.telegram.org/file/bot'.$this->config->get('token').'/'.$path->result->file_path;
         }
 
         return [new Video($url, $video)];

--- a/tests/TelegramDriverTest.php
+++ b/tests/TelegramDriverTest.php
@@ -19,6 +19,13 @@ use BotMan\BotMan\Messages\Outgoing\Actions\Button;
 
 class TelegramDriverTest extends PHPUnit_Framework_TestCase
 {
+
+    protected $telegramConfig = [
+        'telegram' => [
+            'token' => 'TELEGRAM-BOT-TOKEN',
+        ]
+    ];
+
     public function tearDown()
     {
         m::close();
@@ -281,9 +288,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn('');
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
         $botman->say('Test', '12345', $driver);
 
         $this->assertInstanceOf(TelegramDriver::class, $botman->getDriver());
@@ -326,9 +331,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $this->assertSame('FooBar', $driver->getConversationAnswer($message)->getText());
@@ -364,9 +367,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload('Test', $message));
@@ -421,9 +422,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload($question, $message));
@@ -479,9 +478,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload($question, $message));
@@ -517,9 +514,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload('Test', $message, [
@@ -534,14 +529,14 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('getContent')->andReturn('');
         $htmlInterface = m::mock(Curl::class);
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $htmlInterface);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $htmlInterface);
 
         $this->assertTrue($driver->isConfigured());
 
         $driver = new TelegramDriver($request, [
-            'telegram_token' => null,
+            'telegram' => [
+                'token' => null
+            ]
         ], $htmlInterface);
 
         $this->assertFalse($driver->isConfigured());
@@ -580,9 +575,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test'), $message));
@@ -618,9 +611,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', Image::url('http://image.url/foo.png')), $message));
@@ -656,9 +647,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', Image::url('http://image.url/foo.gif')), $message));
@@ -694,9 +683,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', Video::url('http://image.url/foo.mp4')), $message));
@@ -732,9 +719,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test',
@@ -771,9 +756,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', File::url('http://image.url/foo.pdf')), $message));
@@ -810,9 +793,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-        $driver = new TelegramDriver($request, [
-            'telegram_token' => 'TELEGRAM-BOT-TOKEN',
-        ], $html);
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', new Location('123', '321')), $message));


### PR DESCRIPTION
Instead of a big botman config array there is no an array for every driver. In this PR I changed that the Telegram token now is loaded from the telegram config array.