### PR TITLE
Fix for keyboard hiding in interactive reply

### DIFF
--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -68,18 +68,18 @@ class TelegramDriver extends HttpDriver
         return $noAttachments && (! is_null($this->event->get('from')) || ! is_null($this->payload->get('callback_query'))) && ! is_null($this->payload->get('update_id'));
     }
 
+    /**
+     * This hide the inline keyboard, if is an interactive message.
+     */
+    public function messagesHandled()
+    {
+        $callback = $this->payload->get('callback_query');
 
-	/**
-	 * This hide the inline keyboard, if is an interactive message.
-	 */
-	public function messagesHandled() {
-    	$callback = $this->payload->get('callback_query');
-
-	    if ($callback !== null) {
-		    $callback['message']['chat']['id'];
-		    $this->removeInlineKeyboard($callback['message']['chat']['id'],
-			    $callback['message']['message_id']);
-	    }
+        if ($callback !== null) {
+            $callback['message']['chat']['id'];
+            $this->removeInlineKeyboard($callback['message']['chat']['id'],
+                $callback['message']['message_id']);
+        }
     }
 
     /**
@@ -140,6 +140,7 @@ class TelegramDriver extends HttpDriver
             'chat_id' => $matchingMessage->getRecipient(),
             'action' => 'typing',
         ];
+
         return $this->http->post('https://api.telegram.org/bot'.$this->config->get('token').'/sendChatAction', [],
             $parameters);
     }

--- a/tests/TelegramDriverTest.php
+++ b/tests/TelegramDriverTest.php
@@ -2,9 +2,6 @@
 
 namespace Tests;
 
-use BotMan\BotMan\Drivers\Tests\FakeDriver;
-use BotMan\BotMan\Messages\Incoming\IncomingMessage;
-use Illuminate\Support\Collection;
 use Mockery as m;
 use BotMan\BotMan\Http\Curl;
 use PHPUnit_Framework_TestCase;
@@ -336,29 +333,29 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_hides_keyboard()
     {
-	    $responseData = [
-		    'update_id' => '1234567890',
-		    'callback_query' => [
-			    'id' => '11717237123',
-			    'from' => [
-				    'id' => 'from_id',
-			    ],
-			    'message' => [
-				    'message_id' => '123',
-				    'from' => [
-					    'id' => 'from_id',
-				    ],
-				    'chat' => [
-					    'id' => '1234',
-				    ],
-				    'date' => '1480369277',
-				    'text' => 'Telegram Text',
-			    ],
-			    'data' => 'FooBar',
-		    ],
-	    ];
+        $responseData = [
+            'update_id' => '1234567890',
+            'callback_query' => [
+                'id' => '11717237123',
+                'from' => [
+                    'id' => 'from_id',
+                ],
+                'message' => [
+                    'message_id' => '123',
+                    'from' => [
+                        'id' => 'from_id',
+                    ],
+                    'chat' => [
+                        'id' => '1234',
+                    ],
+                    'date' => '1480369277',
+                    'text' => 'Telegram Text',
+                ],
+                'data' => 'FooBar',
+            ],
+        ];
 
-	    $html = m::mock(Curl::class);
+        $html = m::mock(Curl::class);
         $html->shouldReceive('post')
             ->once()
             ->with('https://api.telegram.org/botTELEGRAM-BOT-TOKEN/editMessageReplyMarkup', [], [
@@ -367,13 +364,12 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
                 'inline_keyboard' => [],
             ]);
 
+        $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
+        $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
 
-	    $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
-	    $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
-	    $driver = new TelegramDriver($request, $this->telegramConfig, $html);
-
-	    $driver->messagesHandled();
+        $driver->messagesHandled();
     }
 
     /** @test */


### PR DESCRIPTION
This will avoid useless call to the Telegram api. Now the keyboard hide is done when the response is handled.
This contains also some little changes in getUser and types functions.