### PR TITLE
TelegramDriver expects a token key instead of telegram_token

### DIFF
--- a/stubs/telegram.php
+++ b/stubs/telegram.php
@@ -11,5 +11,5 @@ return [
     | the chatbot through Telegram.
     |
     */
-    'telegram_token' => env('TELEGRAM_TOKEN'),
+    'token' => env('TELEGRAM_TOKEN'),
 ];


### PR DESCRIPTION
TelegramDriver config is build using:
$this->config = Collection::make($this->config->get('telegram'));

And later on the Driver expects the token to be keyed as 'token' in the config property instead of 'telegram_token'.

https://github.com/botman/driver-telegram/blob/master/src/TelegramDriver.php#L293