### PR TITLE
Issue with Events and secondary drivers that extends TelegramDriver main class

### DIFF
--- a/src/TelegramAudioDriver.php
+++ b/src/TelegramAudioDriver.php
@@ -21,6 +21,14 @@ class TelegramAudioDriver extends TelegramDriver
     }
 
     /**
+     * @return bool
+     */
+    public function hasMatchingEvent()
+    {
+        return false;
+    }
+
+    /**
      * Retrieve the chat message.
      *
      * @return array

--- a/src/TelegramFileDriver.php
+++ b/src/TelegramFileDriver.php
@@ -21,6 +21,15 @@ class TelegramFileDriver extends TelegramDriver
     }
 
     /**
+     * @return bool
+     */
+    public function hasMatchingEvent()
+    {
+        return false;
+    }
+
+
+    /**
      * Retrieve the chat message.
      *
      * @return array

--- a/src/TelegramFileDriver.php
+++ b/src/TelegramFileDriver.php
@@ -28,7 +28,6 @@ class TelegramFileDriver extends TelegramDriver
         return false;
     }
 
-
     /**
      * Retrieve the chat message.
      *

--- a/src/TelegramLocationDriver.php
+++ b/src/TelegramLocationDriver.php
@@ -20,6 +20,15 @@ class TelegramLocationDriver extends TelegramDriver
     }
 
     /**
+     * @return bool
+     */
+    public function hasMatchingEvent()
+    {
+        return false;
+    }
+
+
+    /**
      * Retrieve the chat message.
      *
      * @return array

--- a/src/TelegramLocationDriver.php
+++ b/src/TelegramLocationDriver.php
@@ -27,7 +27,6 @@ class TelegramLocationDriver extends TelegramDriver
         return false;
     }
 
-
     /**
      * Retrieve the chat message.
      *

--- a/src/TelegramPhotoDriver.php
+++ b/src/TelegramPhotoDriver.php
@@ -29,7 +29,6 @@ class TelegramPhotoDriver extends TelegramDriver
         return false;
     }
 
-
     /**
      * Retrieve the chat message.
      *

--- a/src/TelegramPhotoDriver.php
+++ b/src/TelegramPhotoDriver.php
@@ -22,6 +22,15 @@ class TelegramPhotoDriver extends TelegramDriver
     }
 
     /**
+     * @return bool
+     */
+    public function hasMatchingEvent()
+    {
+        return false;
+    }
+
+
+    /**
      * Retrieve the chat message.
      *
      * @return array

--- a/src/TelegramVideoDriver.php
+++ b/src/TelegramVideoDriver.php
@@ -28,7 +28,6 @@ class TelegramVideoDriver extends TelegramDriver
         return false;
     }
 
-
     /**
      * Retrieve the chat message.
      *

--- a/src/TelegramVideoDriver.php
+++ b/src/TelegramVideoDriver.php
@@ -21,6 +21,15 @@ class TelegramVideoDriver extends TelegramDriver
     }
 
     /**
+     * @return bool
+     */
+    public function hasMatchingEvent()
+    {
+        return false;
+    }
+
+
+    /**
      * Retrieve the chat message.
      *
      * @return array

--- a/tests/TelegramAudioDriverTest.php
+++ b/tests/TelegramAudioDriverTest.php
@@ -240,4 +240,31 @@ class TelegramAudioDriverTest extends PHPUnit_Framework_TestCase
             $this->assertSame(TelegramAttachmentException::class, get_class($t));
         }
     }
+
+    /** @test */
+    public function it_havent_to_match_any_event()
+    {
+        $driver = $this->getDriver([
+            'update_id' => '1234567890',
+            'message' => [
+                'message_id' => '123',
+                'from' => [
+                    'id' => 'from_id',
+                ],
+                'chat' => [
+                    'id' => 'chat_id',
+                ],
+                'date' => '1480369277',
+                'text' => 'Hi Julia',
+                'new_chat_member' => [
+                    'id' => '456',
+                    'first_name' => 'Marcel',
+                    'last_name' => 'Pociot',
+                    'username' => 'mpociot',
+                ],
+            ],
+        ]);
+        $this->assertFalse($driver->matchesRequest());
+        $this->assertFalse($driver->hasMatchingEvent());
+    }
 }

--- a/tests/TelegramFileDriverTest.php
+++ b/tests/TelegramFileDriverTest.php
@@ -169,4 +169,31 @@ class TelegramFileDriverTest extends PHPUnit_Framework_TestCase
             $this->assertSame(TelegramAttachmentException::class, get_class($t));
         }
     }
+
+    /** @test */
+    public function it_havent_to_match_any_event()
+    {
+        $driver = $this->getDriver([
+            'update_id' => '1234567890',
+            'message' => [
+                'message_id' => '123',
+                'from' => [
+                    'id' => 'from_id',
+                ],
+                'chat' => [
+                    'id' => 'chat_id',
+                ],
+                'date' => '1480369277',
+                'text' => 'Hi Julia',
+                'new_chat_member' => [
+                    'id' => '456',
+                    'first_name' => 'Marcel',
+                    'last_name' => 'Pociot',
+                    'username' => 'mpociot',
+                ],
+            ],
+        ]);
+        $this->assertFalse($driver->matchesRequest());
+        $this->assertFalse($driver->hasMatchingEvent());
+    }
 }

--- a/tests/TelegramLocationDriverTest.php
+++ b/tests/TelegramLocationDriverTest.php
@@ -105,4 +105,31 @@ class TelegramLocationDriverTest extends PHPUnit_Framework_TestCase
             'longitude' => -122.123854248,
         ], $location->getPayload());
     }
+
+    /** @test */
+    public function it_havent_to_match_any_event()
+    {
+        $driver = $this->getDriver([
+            'update_id' => '1234567890',
+            'message' => [
+                'message_id' => '123',
+                'from' => [
+                    'id' => 'from_id',
+                ],
+                'chat' => [
+                    'id' => 'chat_id',
+                ],
+                'date' => '1480369277',
+                'text' => 'Hi Julia',
+                'new_chat_member' => [
+                    'id' => '456',
+                    'first_name' => 'Marcel',
+                    'last_name' => 'Pociot',
+                    'username' => 'mpociot',
+                ],
+            ],
+        ]);
+        $this->assertFalse($driver->matchesRequest());
+        $this->assertFalse($driver->hasMatchingEvent());
+    }
 }

--- a/tests/TelegramPhotoDriverTest.php
+++ b/tests/TelegramPhotoDriverTest.php
@@ -177,4 +177,31 @@ class TelegramPhotoDriverTest extends PHPUnit_Framework_TestCase
             $this->assertSame(TelegramAttachmentException::class, get_class($t));
         }
     }
+
+    /** @test */
+    public function it_havent_to_match_any_event()
+    {
+        $driver = $this->getDriver([
+            'update_id' => '1234567890',
+            'message' => [
+                'message_id' => '123',
+                'from' => [
+                    'id' => 'from_id',
+                ],
+                'chat' => [
+                    'id' => 'chat_id',
+                ],
+                'date' => '1480369277',
+                'text' => 'Hi Julia',
+                'new_chat_member' => [
+                    'id' => '456',
+                    'first_name' => 'Marcel',
+                    'last_name' => 'Pociot',
+                    'username' => 'mpociot',
+                ],
+            ],
+        ]);
+        $this->assertFalse($driver->matchesRequest());
+        $this->assertFalse($driver->hasMatchingEvent());
+    }
 }

--- a/tests/TelegramVideoDriverTest.php
+++ b/tests/TelegramVideoDriverTest.php
@@ -188,4 +188,31 @@ class TelegramVideoDriverTest extends PHPUnit_Framework_TestCase
             $this->assertSame(TelegramAttachmentException::class, get_class($t));
         }
     }
+
+    /** @test */
+    public function it_havent_to_match_any_event()
+    {
+        $driver = $this->getDriver([
+            'update_id' => '1234567890',
+            'message' => [
+                'message_id' => '123',
+                'from' => [
+                    'id' => 'from_id',
+                ],
+                'chat' => [
+                    'id' => 'chat_id',
+                ],
+                'date' => '1480369277',
+                'text' => 'Hi Julia',
+                'new_chat_member' => [
+                    'id' => '456',
+                    'first_name' => 'Marcel',
+                    'last_name' => 'Pociot',
+                    'username' => 'mpociot',
+                ],
+            ],
+        ]);
+        $this->assertFalse($driver->matchesRequest());
+        $this->assertFalse($driver->hasMatchingEvent());
+    }
 }


### PR DESCRIPTION
Secondary Telegram drivers doesn't have any Event so should all be ignored at all. Now it's fixed!