### PR TITLE
Enables ability to parse video notes as videos

### DIFF
--- a/src/TelegramVideoDriver.php
+++ b/src/TelegramVideoDriver.php
@@ -17,7 +17,7 @@ class TelegramVideoDriver extends TelegramDriver
      */
     public function matchesRequest()
     {
-        return ! is_null($this->event->get('from')) && ! is_null($this->event->get('video'));
+        return ! is_null($this->event->get('from')) && (! is_null($this->event->get('video')) || ! is_null($this->event->get('video_note')));
     }
 
     /**
@@ -61,7 +61,7 @@ class TelegramVideoDriver extends TelegramDriver
      */
     private function getVideos()
     {
-        $video = $this->event->get('video');
+        $video = $this->event->get('video') ?: $this->event->get('video_note');
         $response = $this->http->get('https://api.telegram.org/bot'.$this->config->get('token').'/getFile', [
             'file_id' => $video['file_id'],
         ]);


### PR DESCRIPTION
Hi there,

It would be great if the library treated video notes as videos. These are the quick-send videos that you can send by holding the camera button in Telegram. Super useful for quick video updates etc.

These proposed changes appear to work and all tests are passing, I believe these changes are covered by existing tests - this is my first day working with BotMan (great work by the way it's fantastic!) - so I'm not entirely sure if I'm missing anything.

Hope you find it satisfactory.

Cheers,
Luke