### PR TITLE
Add ability to use single-row buttons

### DIFF
--- a/src/Extensions/Question.php
+++ b/src/Extensions/Question.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace BotMan\Drivers\Telegram\Extensions;
+
+use BotMan\BotMan\Messages\Outgoing\Question as BotManQuestion;
+use Illuminate\Support\Collection;
+
+class Question extends BotManQuestion
+{
+
+    protected $buttonsInSingleRow = false;
+
+    public function getButtonsToArray()
+    {
+        $replies = Collection::make($this->getButtons())->map(function ($button) {
+            return [
+                array_merge([
+                    'text'          => (string)$button['text'],
+                    'callback_data' => (string)$button['value'],
+                ], $button['additional']),
+            ];
+        });
+
+        if ($this->buttonsInSingleRow) {
+
+            return [$replies->flatten(1)->toArray()];
+        }
+
+        return $replies->toArray();
+    }
+
+    public function buttonsInSingleRow()
+    {
+        $this->buttonsInSingleRow = true;
+
+        return $this;
+    }
+
+    public function buttonsInMultipleRows()
+    {
+        $this->buttonsInSingleRow = false;
+
+        return $this;
+    }
+
+}

--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -2,6 +2,7 @@
 
 namespace BotMan\Drivers\Telegram;
 
+use BotMan\Drivers\Telegram\Extensions\Question as TelegramQuestion;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Drivers\HttpDriver;
 use BotMan\BotMan\Messages\Incoming\Answer;
@@ -256,6 +257,10 @@ class TelegramDriver extends HttpDriver
      */
     private function convertQuestion(Question $question)
     {
+        if ($question instanceof TelegramQuestion) {
+            return $question->getButtonsToArray();
+        }
+
         $replies = Collection::make($question->getButtons())->map(function ($button) {
             return [
                 array_merge([

--- a/tests/TelegramQuestionTest.php
+++ b/tests/TelegramQuestionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests;
+
+use BotMan\BotMan\Messages\Outgoing\Actions\Button;
+use BotMan\Drivers\Telegram\Extensions\Question;
+use PHPUnit_Framework_TestCase;
+
+class TelegramQuestionTest extends PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_can_have_buttons_in_multiple_rows()
+    {
+        $question = Question::create('How are you doing?')
+            ->addButton(Button::create('Great')->value('great'))
+            ->addButton(Button::create('Good')->value('good'));
+        
+        $buttons = $question->getButtonsToArray();
+
+        $this->assertCount(2, $buttons);
+    }
+
+    /** @test */
+    public function it_can_have_buttons_in_one_row()
+    {
+        $question = Question::create('How are you doing?')
+            ->addButton(Button::create('Great')->value('great'))
+            ->addButton(Button::create('Good')->value('good'));
+
+        $buttons = $question->buttonsInSingleRow()->getButtonsToArray();
+
+        $this->assertCount(1, $buttons);
+    }
+}


### PR DESCRIPTION
I have an easy question about yes/no and I wanted to show those buttons in a single row.

I have extended the Botman's Question class to add this logic.

Maybe another possible improvement will be to delegate the conversion of question buttons to the Question object itself. That way the conditional will not be needed.