### PR TITLE
Don't remove inline keyboard automatically (Closes #44, closes #29, closes botman/botman#709)

### DIFF
--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -160,8 +160,9 @@ class TelegramDriver extends HttpDriver
     public function messagesHandled()
     {
         $callback = $this->payload->get('callback_query');
+        $hideInlineKeyboard = $this->config->get('hideInlineKeyboard', true);
 
-        if ($callback !== null) {
+        if ($callback !== null && $hideInlineKeyboard) {
             $callback['message']['chat']['id'];
             $this->removeInlineKeyboard($callback['message']['chat']['id'],
                 $callback['message']['message_id']);

--- a/tests/TelegramDriverTest.php
+++ b/tests/TelegramDriverTest.php
@@ -626,7 +626,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_hides_keyboard()
+    public function it_hides_keyboard_by_default()
     {
         $responseData = [
             'update_id' => '1234567890',
@@ -666,6 +666,49 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
 
         $driver->messagesHandled();
     }
+
+    /** @test */
+    public function it_does_not_hide_keyboard_if_configured()
+    {
+        $responseData = [
+            'update_id' => '1234567890',
+            'callback_query' => [
+                'id' => '11717237123',
+                'from' => [
+                    'id' => 'from_id',
+                ],
+                'message' => [
+                    'message_id' => '123',
+                    'from' => [
+                        'id' => 'from_id',
+                    ],
+                    'chat' => [
+                        'id' => '1234',
+                    ],
+                    'date' => '1480369277',
+                    'text' => 'Telegram Text',
+                ],
+                'data' => 'FooBar',
+            ],
+        ];
+
+        $html = m::mock(Curl::class);
+        $html->shouldNotReceive('post');
+
+        $request = m::mock(Request::class.'[getContent]');
+        $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
+
+        $telegramConfig = [
+            'telegram' => [
+                'token' => 'TELEGRAM-BOT-TOKEN',
+                'hideInlineKeyboard' => false
+            ],
+        ];
+        $driver = new TelegramDriver($request, $telegramConfig, $html);
+
+        $driver->messagesHandled();
+    }
+
 
     /** @test */
     public function it_can_reply_string_messages()


### PR DESCRIPTION
Implemented without BC break.
#44 
#29 
botman/botman#709