### PR TITLE
Telegram Login Event - Edge Cases Validation

### DIFF
--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -138,6 +138,9 @@ class TelegramDriver extends HttpDriver
         // Get sorted array of values
         $check = $this->queryParameters
             ->except('hash')
+            ->filter(function ($value) {
+                return !is_array($value);
+            })
             ->map(function ($value, $key) {
                 return $key.'='.$value;
             })

--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -131,6 +131,10 @@ class TelegramDriver extends HttpDriver
     {
         $check_hash = $this->queryParameters->get('hash');
 
+        if (empty($check_hash)) {
+            return false;
+        }
+
         // Get sorted array of values
         $check = $this->queryParameters
             ->except('hash')

--- a/tests/TelegramDriverTest.php
+++ b/tests/TelegramDriverTest.php
@@ -346,6 +346,26 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_does_not_call_telegram_login_event_when_check_hash_is_not_present()
+    {
+        $token = 'randomtoken';
+
+        $queryParameters = [
+            'hash' => null,
+        ];
+
+        $request = new Request($queryParameters);
+
+        $driver = new TelegramDriver($request, [
+            'telegram' => [
+                'token' => $token,
+            ],
+        ], m::mock(Curl::class));
+
+        $this->assertFalse($driver->hasMatchingEvent());
+    }
+
+    /** @test */
     public function telegram_login_event_has_the_correct_chat_id()
     {
         $token = 'randomtoken';


### PR DESCRIPTION
Hi. This PR tries to address an issue found with query parameters during the login event. When array parameters are present in the url, the validation crashes.

Overview

The `TelegramDriver` runs the `isValidLoginRequest` method on every route hit in a Laravel project I currently have setup with Botman. Botman is setup manually. 

*NOTE: This may or not be the issue so that is why I am describing my current setup.*

**`routes/botman.php`**

![image](https://user-images.githubusercontent.com/5126648/44496465-48883480-a63a-11e8-9ce1-850b28ab3206.png)

I recently installed Laravel Nova to take advantage of this new tool and everything worked except when hitting routes that had array parameters in the url. Nova would complain with a `Array to string conversion` exception thrown by the `TelegramDriver` which I thought was very weird. This got me digging into the matter and found that the issue was on the `isValidLoginRequest` when converting the query parameters to a string. 

![image](https://user-images.githubusercontent.com/5126648/44496595-ca785d80-a63a-11e8-990a-16878b1d1235.png)

Since some of Nova's query parameters were arrays, this method failed.

PS: I am sorry if this is a matter of my project's setup and really not an issue. I appreciate your time. Thanks for Botman and this driver.