### PR TITLE
Add configuration option to enable setting of default additional parameters

### DIFF
--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -298,10 +298,11 @@ class TelegramDriver extends HttpDriver
         $this->endpoint = 'sendMessage';
 
         $recipient = $matchingMessage->getRecipient() === '' ? $matchingMessage->getSender() : $matchingMessage->getRecipient();
+        $defaultAdditionalParameters = $this->config->get('default_additional_parameters', []);
         $parameters = array_merge_recursive([
             'chat_id' => $recipient,
-        ], $additionalParameters);
-
+        ], $additionalParameters + $defaultAdditionalParameters);
+        
         /*
          * If we send a Question with buttons, ignore
          * the text and append the question.


### PR DESCRIPTION
Hi,

Thanks for a great driver. I found myself adding additional Parameters a lot, so I've made this PR to  the ability to configure default additionalParameters that will be set on every payload unless they are overridden by additional parameters from the specific function call. 

Specifically this is to enable defaulting all messages to Markdown format by having the following config:

```
'telegram' => [
	'token' => 'YOUR-TELEGRAM-TOKEN-HERE',
	'default_additional_parameters' =>
	    [
	        'parse_mode' => 'Markdown',
	    ],
]
```

thanks again and all the best