### PR TITLE
Fix bug and failing tests in sendContact

### DIFF
--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -10,6 +10,7 @@ use BotMan\Drivers\Telegram\Extensions\User;
 use BotMan\BotMan\Messages\Attachments\Audio;
 use BotMan\BotMan\Messages\Attachments\Image;
 use BotMan\BotMan\Messages\Attachments\Video;
+use BotMan\BotMan\Messages\Attachments\Contact;
 use BotMan\BotMan\Messages\Outgoing\Question;
 use Symfony\Component\HttpFoundation\Request;
 use BotMan\BotMan\Drivers\Events\GenericEvent;
@@ -349,7 +350,9 @@ class TelegramDriver extends HttpDriver
                     $parameters['first_name'] = $attachment->getFirstName();
                     $parameters['last_name'] = $attachment->getLastName();
                     $parameters['user_id'] = $attachment->getUserId();
-                    $parameters['vcard'] = $attachment->getVcard();
+                    if (null !== $attachment->getVcard()) {
+                        $parameters['vcard'] = $attachment->getVcard();
+                    }
                 }
             } else {
                 $parameters['text'] = $message->getText();

--- a/tests/TelegramDriverTest.php
+++ b/tests/TelegramDriverTest.php
@@ -1129,7 +1129,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', new Location('123', '321')), $message));
     }
 
-  	/** @test */
+    /** @test */
     public function it_can_reply_message_objects_with_contact()
     {
         $responseData = [
@@ -1154,9 +1154,9 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
                 'chat_id' => '12345',
                 'phone_number' => '0775269856',
                 'first_name' => 'Daniele',
-                'first_name' => 'Rapisarda',
-				'user_id' => '123',
-				'caption' => 'Test',
+                'last_name' => 'Rapisarda',
+                'user_id' => '123',
+                'caption' => 'Test'
             ]);
 
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
@@ -1166,6 +1166,62 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', new Contact('0775269856', 'Daniele', 'Rapisarda', '123')), $message));
+    }
+
+  	/** @test */
+    public function it_can_reply_message_objects_with_contact_with_vcard()
+    {
+        $responseData = [
+            'update_id' => '1234567890',
+            'message' => [
+                'message_id' => '123',
+                'from' => [
+                    'id' => 'from_id',
+                ],
+                'chat' => [
+                    'id' => '12345',
+                ],
+                'date' => '1480369277',
+                'text' => 'Telegram Text',
+            ],
+        ];
+
+        $vcard = 'BEGIN:VCARD
+VERSION:4.0
+N:Gump;Forrest;;Mr.;
+FN:Forrest Gump
+ORG:Bubba Gump Shrimp Co.
+TITLE:Shrimp Man
+PHOTO;MEDIATYPE=image/gif:http://www.example.com/dir_photos/my_photo.gif
+TEL;TYPE=work,voice;VALUE=uri:tel:+1-111-555-1212
+TEL;TYPE=home,voice;VALUE=uri:tel:+1-404-555-1212
+ADR;TYPE=WORK;PREF=1;LABEL="100 Waters Edge\nBaytown\, LA 30314\nUnited States of America":;;100 Waters Edge;Baytown;LA;30314;United States of America
+ADR;TYPE=HOME;LABEL="42 Plantation St.\nBaytown\, LA 30314\nUnited States of America":;;42 Plantation St.;Baytown;LA;30314;United States of America
+EMAIL:forrestgump@example.com
+REV:20080424T195243Z
+x-qq:21588891
+END:VCARD';
+
+        $html = m::mock(Curl::class);
+        $html->shouldReceive('post')
+            ->once()
+            ->with('https://api.telegram.org/botTELEGRAM-BOT-TOKEN/sendContact', [], [
+                'chat_id' => '12345',
+                'phone_number' => '0775269856',
+                'first_name' => 'Daniele',
+                'last_name' => 'Rapisarda',
+				'user_id' => '123',
+				'caption' => 'Test',
+                'vcard' => $vcard,
+            ]);
+
+        $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
+        $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
+
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
+
+        $message = $driver->getMessages()[0];
+        $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', new Contact('0775269856', 'Daniele', 'Rapisarda', '123', $vcard)), $message));
     }
 
     /** @test */

--- a/tests/TelegramDriverTest.php
+++ b/tests/TelegramDriverTest.php
@@ -1168,7 +1168,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', new Contact('0775269856', 'Daniele', 'Rapisarda', '123')), $message));
     }
 
-  	/** @test */
+    /** @test */
     public function it_can_reply_message_objects_with_contact_with_vcard()
     {
         $responseData = [
@@ -1210,8 +1210,8 @@ END:VCARD';
                 'phone_number' => '0775269856',
                 'first_name' => 'Daniele',
                 'last_name' => 'Rapisarda',
-				'user_id' => '123',
-				'caption' => 'Test',
+                'user_id' => '123',
+                'caption' => 'Test',
                 'vcard' => $vcard,
             ]);
 


### PR DESCRIPTION
Hi again,

There was a missing use statement for Contact and it was sending the vcard parameter even when there was no vcard set. I've fixed the code and added a test for the vcard variation. 

All the best