### PR TITLE
Optionally throw exception when http call fails.

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,5 +2,3 @@ preset: laravel
 
 enabled:
   - unalign_double_arrow
-
-linting: true

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,1 @@
-preset: laravel
-
-enabled:
-  - unalign_double_arrow
+preset: psr2

--- a/src/Exceptions/TelegramConnectionException.php
+++ b/src/Exceptions/TelegramConnectionException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BotMan\Drivers\Telegram\Exceptions;
+
+use BotMan\BotMan\Exceptions\Base\DriverException;
+
+class TelegramConnectionException extends DriverException
+{
+}

--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -86,8 +86,13 @@ class TelegramDriver extends HttpDriver
 
         $userData = Collection::make($responseData['result']['user']);
 
-        return new User($userData->get('id'), $userData->get('first_name'), $userData->get('last_name'),
-            $userData->get('username'), $responseData['result']);
+        return new User(
+            $userData->get('id'),
+            $userData->get('first_name'),
+            $userData->get('last_name'),
+            $userData->get('username'),
+            $responseData['result']
+        );
     }
 
     /**
@@ -170,8 +175,10 @@ class TelegramDriver extends HttpDriver
 
         if ($callback !== null) {
             $callback['message']['chat']['id'];
-            $this->removeInlineKeyboard($callback['message']['chat']['id'],
-                $callback['message']['message_id']);
+            $this->removeInlineKeyboard(
+                $callback['message']['chat']['id'],
+                $callback['message']['message_id']
+            );
         }
     }
 
@@ -216,8 +223,12 @@ class TelegramDriver extends HttpDriver
             $callback = Collection::make($this->payload->get('callback_query'));
 
             $messages = [
-                new IncomingMessage($callback->get('data'), $callback->get('from')['id'],
-                    $callback->get('message')['chat']['id'], $callback->get('message')),
+                new IncomingMessage(
+                    $callback->get('data'),
+                    $callback->get('from')['id'],
+                    $callback->get('message')['chat']['id'],
+                    $callback->get('message')
+                ),
             ];
         } elseif ($this->isValidLoginRequest()) {
             $messages = [
@@ -225,8 +236,12 @@ class TelegramDriver extends HttpDriver
             ];
         } else {
             $messages = [
-                new IncomingMessage($this->event->get('text'), $this->event->get('from')['id'], $this->event->get('chat')['id'],
-                    $this->event),
+                new IncomingMessage(
+                    $this->event->get('text'),
+                    $this->event->get('from')['id'],
+                    $this->event->get('chat')['id'],
+                    $this->event
+                ),
             ];
         }
 
@@ -460,7 +475,7 @@ class TelegramDriver extends HttpDriver
         $responseData = json_decode($response->getContent(), true);
         if ($response->isOk() && isset($responseData['ok']) && true ===  $responseData['ok']) {
             return $response;
-        } elseif ($this->config->get('retry_http_exceptions') && $retryCount <= $this->config->get('retry_http_exceptions') ) {
+        } elseif ($this->config->get('retry_http_exceptions') && $retryCount <= $this->config->get('retry_http_exceptions')) {
             $retryCount++;
             if ($response->getStatusCode() == 429 && isset($responseData['retry_after']) && is_numeric($responseData['retry_after'])) {
                 usleep($responseData['retry_after'] * 1000000);
@@ -468,7 +483,7 @@ class TelegramDriver extends HttpDriver
                 $multiplier = $this->config->get('retry_http_exceptions_multiplier')??2;
                 usleep($retryCount*$multiplier* 1000000);
             }
-            return $this->postWithExceptionHandling($url,$urlParameters, $postParameters, $headers , $asJSON, $retryCount);
+            return $this->postWithExceptionHandling($url, $urlParameters, $postParameters, $headers, $asJSON, $retryCount);
         }
         $responseData['description'] = $responseData['description'] ?? 'No description from Telegram';
         $responseData['error_code'] = $responseData['error_code'] ?? 'No error code from Telegram';
@@ -480,12 +495,11 @@ class TelegramDriver extends HttpDriver
             "Error Code: ".print_r($responseData['error_code'], true)."\n".
             "Parameters: ".print_r($responseData['parameters'], true)."\n".
             "URL: $url\n".
-            "URL Parameters: ".print_r($urlParameters,true)."\n".
+            "URL Parameters: ".print_r($urlParameters, true)."\n".
             "Post Parameters: ".print_r($postParameters, true)."\n".
-            "Headers: ". print_r($headers,true)."\n";
+            "Headers: ". print_r($headers, true)."\n";
 
         $message = str_replace($this->config->get('token'), 'TELEGRAM-TOKEN-HIDDEN', $message);
         throw new TelegramConnectionException($message);
-
     }
 }

--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -460,7 +460,8 @@ class TelegramDriver extends HttpDriver
             "Post Parameters: ".print_r($postParameters, true)."\n".
             "Headers: ". print_r($headers,true)."\n";
 
-        throw new TelegramConnectionException($message );
+        $message = str_replace($this->config->get('token'), 'TELEGRAM-TOKEN-HIDDEN', $message);
+        throw new TelegramConnectionException($message);
 
     }
 }

--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -11,6 +11,7 @@ use BotMan\Drivers\Telegram\Extensions\User;
 use BotMan\BotMan\Messages\Attachments\Audio;
 use BotMan\BotMan\Messages\Attachments\Image;
 use BotMan\BotMan\Messages\Attachments\Video;
+use BotMan\BotMan\Messages\Attachments\Contact;
 use BotMan\BotMan\Messages\Outgoing\Question;
 use Symfony\Component\HttpFoundation\Request;
 use BotMan\BotMan\Drivers\Events\GenericEvent;
@@ -360,7 +361,9 @@ class TelegramDriver extends HttpDriver
                     $parameters['first_name'] = $attachment->getFirstName();
                     $parameters['last_name'] = $attachment->getLastName();
                     $parameters['user_id'] = $attachment->getUserId();
-                    $parameters['vcard'] = $attachment->getVcard();
+                    if (null !== $attachment->getVcard()) {
+                        $parameters['vcard'] = $attachment->getVcard();
+                    }
                 }
             } else {
                 $parameters['text'] = $message->getText();

--- a/tests/TelegramDriverTest.php
+++ b/tests/TelegramDriverTest.php
@@ -937,14 +937,16 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $message = $driver->getMessages()[0];
         $throwable = null;
         try {
-            $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('unparsable_string'),
-                $message, ['parse_mode' => 'MarkdownV2']));
-        }  catch (\Throwable $t) {
+            $driver->sendPayload($driver->buildServicePayload(
+                \BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('unparsable_string'),
+                $message,
+                ['parse_mode' => 'MarkdownV2']
+            ));
+        } catch (\Throwable $t) {
             $throwable = $t;
             throw $t;
         }
         $this->assertNull($throwable);
-
     }
 
     /** @test */
@@ -975,9 +977,12 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $message = $driver->getMessages()[0];
         $throwable = null;
         try {
-            $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('unparsable_string'),
-                $message, ['parse_mode' => 'MarkdownV2']));
-        }  catch (\Throwable $t) {
+            $driver->sendPayload($driver->buildServicePayload(
+                \BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('unparsable_string'),
+                $message,
+                ['parse_mode' => 'MarkdownV2']
+            ));
+        } catch (\Throwable $t) {
             $throwable = $t;
         }
         $this->assertNotNull($throwable);
@@ -997,7 +1002,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
             'chat_id' => null,
             'parse_mode' => 'MarkdownV2',
             'text' => 'a message'
-        ], [], false)->times(3)->andReturn(clone $responseFailed, clone $responseFailed, $responseSucceeds );
+        ], [], false)->times(3)->andReturn(clone $responseFailed, clone $responseFailed, $responseSucceeds);
 
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn($responseFailed);
@@ -1015,10 +1020,13 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $duration = 0.0;
         try {
             $start = microtime(true);
-            $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('a message'),
-                $message, ['parse_mode' => 'MarkdownV2']));
+            $driver->sendPayload($driver->buildServicePayload(
+                \BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('a message'),
+                $message,
+                ['parse_mode' => 'MarkdownV2']
+            ));
             $duration = microtime(true) - $start;
-        }  catch (\Throwable $t) {
+        } catch (\Throwable $t) {
             $throwable = $t;
         }
         $this->assertNull($throwable);
@@ -1036,7 +1044,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
             'chat_id' => null,
             'parse_mode' => 'MarkdownV2',
             'text' => 'a message'
-        ], [], false)->times(2)->andReturn($response429, $responseSucceeds );
+        ], [], false)->times(2)->andReturn($response429, $responseSucceeds);
 
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn($response429);
@@ -1053,10 +1061,13 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $duration = 0.0;
         try {
             $start = microtime(true);
-            $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('a message'),
-                $message, ['parse_mode' => 'MarkdownV2']));
+            $driver->sendPayload($driver->buildServicePayload(
+                \BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('a message'),
+                $message,
+                ['parse_mode' => 'MarkdownV2']
+            ));
             $duration = microtime(true) - $start;
-        }  catch (\Throwable $t) {
+        } catch (\Throwable $t) {
             $throwable = $t;
         }
         $this->assertNull($throwable);
@@ -1204,8 +1215,10 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $driver = new TelegramDriver($request, $this->telegramConfig, $html);
 
         $message = $driver->getMessages()[0];
-        $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test',
-            Audio::url('http://image.url/foo.mp3')), $message));
+        $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create(
+            'Test',
+            Audio::url('http://image.url/foo.mp3')
+        ), $message));
     }
 
     /** @test */
@@ -1410,7 +1423,6 @@ END:VCARD';
         }
         $this->assertNotNull($throwable);
         $this->assertSame(TelegramException::class, get_class($throwable));
-
     }
 
     /** @test */

--- a/tests/TelegramDriverTest.php
+++ b/tests/TelegramDriverTest.php
@@ -982,6 +982,8 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         }
         $this->assertNotNull($throwable);
         $this->assertSame(TelegramConnectionException::class, get_class($throwable));
+        $this->assertNotContains($configurationWithHttpExceptions['telegram']['token'], $throwable->getMessage());
+        $this->assertContains('TELEGRAM-TOKEN-HIDDEN', $throwable->getMessage());
     }
 
     /** @test */

--- a/tests/TelegramDriverTest.php
+++ b/tests/TelegramDriverTest.php
@@ -1243,7 +1243,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', new Contact('0775269856', 'Daniele', 'Rapisarda', '123')), $message));
     }
 
-  	/** @test */
+    /** @test */
     public function it_can_reply_message_objects_with_contact_with_vcard()
     {
         $responseData = [
@@ -1285,8 +1285,8 @@ END:VCARD';
                 'phone_number' => '0775269856',
                 'first_name' => 'Daniele',
                 'last_name' => 'Rapisarda',
-				'user_id' => '123',
-				'caption' => 'Test',
+                'user_id' => '123',
+                'caption' => 'Test',
                 'vcard' => $vcard,
             ]);
 

--- a/tests/TelegramDriverTest.php
+++ b/tests/TelegramDriverTest.php
@@ -1204,7 +1204,7 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', new Location('123', '321')), $message));
     }
 
-  	/** @test */
+    /** @test */
     public function it_can_reply_message_objects_with_contact()
     {
         $responseData = [
@@ -1229,9 +1229,9 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
                 'chat_id' => '12345',
                 'phone_number' => '0775269856',
                 'first_name' => 'Daniele',
-                'first_name' => 'Rapisarda',
-				'user_id' => '123',
-				'caption' => 'Test',
+                'last_name' => 'Rapisarda',
+                'user_id' => '123',
+                'caption' => 'Test'
             ]);
 
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
@@ -1241,6 +1241,62 @@ class TelegramDriverTest extends PHPUnit_Framework_TestCase
 
         $message = $driver->getMessages()[0];
         $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', new Contact('0775269856', 'Daniele', 'Rapisarda', '123')), $message));
+    }
+
+  	/** @test */
+    public function it_can_reply_message_objects_with_contact_with_vcard()
+    {
+        $responseData = [
+            'update_id' => '1234567890',
+            'message' => [
+                'message_id' => '123',
+                'from' => [
+                    'id' => 'from_id',
+                ],
+                'chat' => [
+                    'id' => '12345',
+                ],
+                'date' => '1480369277',
+                'text' => 'Telegram Text',
+            ],
+        ];
+
+        $vcard = 'BEGIN:VCARD
+VERSION:4.0
+N:Gump;Forrest;;Mr.;
+FN:Forrest Gump
+ORG:Bubba Gump Shrimp Co.
+TITLE:Shrimp Man
+PHOTO;MEDIATYPE=image/gif:http://www.example.com/dir_photos/my_photo.gif
+TEL;TYPE=work,voice;VALUE=uri:tel:+1-111-555-1212
+TEL;TYPE=home,voice;VALUE=uri:tel:+1-404-555-1212
+ADR;TYPE=WORK;PREF=1;LABEL="100 Waters Edge\nBaytown\, LA 30314\nUnited States of America":;;100 Waters Edge;Baytown;LA;30314;United States of America
+ADR;TYPE=HOME;LABEL="42 Plantation St.\nBaytown\, LA 30314\nUnited States of America":;;42 Plantation St.;Baytown;LA;30314;United States of America
+EMAIL:forrestgump@example.com
+REV:20080424T195243Z
+x-qq:21588891
+END:VCARD';
+
+        $html = m::mock(Curl::class);
+        $html->shouldReceive('post')
+            ->once()
+            ->with('https://api.telegram.org/botTELEGRAM-BOT-TOKEN/sendContact', [], [
+                'chat_id' => '12345',
+                'phone_number' => '0775269856',
+                'first_name' => 'Daniele',
+                'last_name' => 'Rapisarda',
+				'user_id' => '123',
+				'caption' => 'Test',
+                'vcard' => $vcard,
+            ]);
+
+        $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
+        $request->shouldReceive('getContent')->andReturn(json_encode($responseData));
+
+        $driver = new TelegramDriver($request, $this->telegramConfig, $html);
+
+        $message = $driver->getMessages()[0];
+        $driver->sendPayload($driver->buildServicePayload(\BotMan\BotMan\Messages\Outgoing\OutgoingMessage::create('Test', new Contact('0775269856', 'Daniele', 'Rapisarda', '123', $vcard)), $message));
     }
 
     /** @test */


### PR DESCRIPTION
Add configuration option/feature flag named `throw_http_exceptions` to ensure that there are no BC breaks.

Enable in config array: 
```php
'telegram' => [
	'token' => 'YOUR-TELEGRAM-TOKEN-HERE',
        'throw_http_exceptions' => true,
]
```

When set to true this will perform various checks on the response from an http call and throw a TelegramConnectionException if there are any problems. The message content will contain debugging information. The telegram token will be removed from the message so as not to leak credentials. 

Have added new tests for this.

Also fixed it_throws_exception_in_get_user test as it would not have correctly picked up situation where no exception was thrown.