### PR TITLE
Prevent double import

### DIFF
--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -17,7 +17,6 @@ use Symfony\Component\HttpFoundation\Request;
 use BotMan\BotMan\Drivers\Events\GenericEvent;
 use Symfony\Component\HttpFoundation\Response;
 use BotMan\BotMan\Messages\Attachments\Location;
-use BotMan\BotMan\Messages\Attachments\Contact;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 use BotMan\BotMan\Messages\Outgoing\OutgoingMessage;


### PR DESCRIPTION
Cannot use BotMan\BotMan\Messages\Attachments\Contact as Contact because the name is already in use