### PR TITLE
Allow to set switch_inline_query or switch_inline_query_current_chat for Button

### DIFF
--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -288,12 +288,19 @@ class TelegramDriver extends HttpDriver
     private function convertQuestion(Question $question)
     {
         $replies = Collection::make($question->getButtons())->map(function ($button) {
-            return [
-                array_merge([
-                    'text' => (string) $button['text'],
-                    'callback_data' => (string) $button['value'],
-                ], $button['additional']),
+            $data = [
+                'text' => (string) $button['text'],
             ];
+
+            if (!isset($button['additional']['switch_inline_query']) &&
+                !isset($button['additional']['switch_inline_query_current_chat']))
+            {
+                $data['callback_data'] = (string) $button['value'];
+            }
+
+            $data = array_merge($data, $button['additional']);
+
+            return [$data];
         });
 
         return $replies->toArray();


### PR DESCRIPTION
Hi!
To allow implementing Buttons with Inline mode support we need to make callback_data parameter not mandatory. From docs https://core.telegram.org/bots/api#inlinekeyboardbutton
````
InlineKeyboardButton
This object represents one button of an inline keyboard. You must use exactly one of the optional fields.
````
So before this PR setting switch_inline_query param will not affect the result because always existing callback_data param will suppress it.
