### PR TITLE
Add default webhook url to command

### DIFF
--- a/src/Console/Commands/TelegramRegisterCommand.php
+++ b/src/Console/Commands/TelegramRegisterCommand.php
@@ -33,8 +33,12 @@ class TelegramRegisterCommand extends Command
 
         $remove = $this->option('remove', null);
 
+        $defaultWebhook = config('app.url')
+                        .'/bot'
+                        .config('botman.telegram.token');
+
         if (! $remove) {
-            $url .= '?url='.$this->ask('What is the target url for the telegram bot?');
+            $url .= '?url='.$this->ask('What is the target url for the telegram bot?', $defaultWebhook);
         }
 
         $this->info('Using '.$url);


### PR DESCRIPTION
This few lines add a default webhook url to question target url.
The url follows the recommended secret path as stated in https://core.telegram.org/bots/api#setwebhook