### PR TITLE
Fix critical security vulnerability

### DIFF
--- a/src/Console/Commands/TelegramRegisterCommand.php
+++ b/src/Console/Commands/TelegramRegisterCommand.php
@@ -35,7 +35,7 @@ class TelegramRegisterCommand extends Command
 
         if (! $remove) {
             $url .= '?url='.$this->ask('What is the target url for the telegram bot?');
-            $url .= '&secret_token='.config('botman.telegram.token');
+            $url .= '&secret_token='.str_replace(':', '_', env('TELEGRAM_TOKEN'));
         }
 
         $this->info('Using '.$url);

--- a/src/Console/Commands/TelegramRegisterCommand.php
+++ b/src/Console/Commands/TelegramRegisterCommand.php
@@ -35,6 +35,7 @@ class TelegramRegisterCommand extends Command
 
         if (! $remove) {
             $url .= '?url='.$this->ask('What is the target url for the telegram bot?');
+            $url .= '&secret_token='.config('botman.telegram.token');
         }
 
         $this->info('Using '.$url);

--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -61,6 +61,12 @@ class TelegramDriver extends HttpDriver
         $this->event = Collection::make($message);
         $this->config = Collection::make($this->config->get('telegram'));
         $this->queryParameters = Collection::make($request->query);
+
+        $token = $request->headers->get('X-Telegram-Bot-Api-Secret-Token');
+
+        if ($token !== str_replace(':', '_', $this->config->get('token'))) {
+            throw new \Exception('Token mismatch!');
+        }
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/botman/studio/issues/99

- [x] Force Telegram Bot server to send "X-Telegram-Bot-Api-Secret-Token" HTTP header
- [x] Check the header on update request to the webhook

This is a **breaking change** all users must run the `src/Console/Commands/TelegramRegisterCommand.php` console command.

Edits are welcome.