### PR TITLE
Prevent dynamic property creation error

### DIFF
--- a/src/Extensions/Keyboard.php
+++ b/src/Extensions/Keyboard.php
@@ -20,6 +20,8 @@ class Keyboard
      */
     protected $rows = [];
 
+    private $type;
+
     /**
      * @param string $type
      * @return Keyboard

--- a/src/Extensions/Keyboard.php
+++ b/src/Extensions/Keyboard.php
@@ -20,6 +20,9 @@ class Keyboard
      */
     protected $rows = [];
 
+    /**
+     * @var string
+     */
     private $type;
 
     /**


### PR DESCRIPTION
Creation of dynamic property BotMan\Drivers\Telegram\Extensions\Keyboard::$type is deprecated