### PR TITLE
Add missing type property

### DIFF
--- a/src/Extensions/Keyboard.php
+++ b/src/Extensions/Keyboard.php
@@ -21,6 +21,11 @@ class Keyboard
     protected $rows = [];
 
     /**
+     * @var string
+     */
+    private $type;
+    
+    /**
      * @param string $type
      * @return Keyboard
      */


### PR DESCRIPTION
To prevent error `Creation of dynamic property BotMan\Drivers\Telegram\Extensions\Keyboard::$type is deprecated`