### PR TITLE
Dedicated test environment support

### DIFF
--- a/src/Console/Commands/TelegramRegisterCommand.php
+++ b/src/Console/Commands/TelegramRegisterCommand.php
@@ -29,6 +29,7 @@ class TelegramRegisterCommand extends Command
     {
         $url = 'https://api.telegram.org/bot'
                 .config('botman.telegram.token')
+                .(config('botman.telegram.test_environment') ? '/test' : '')
                 .'/setWebhook';
 
         $remove = $this->option('remove', null);

--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -481,7 +481,10 @@ class TelegramDriver extends HttpDriver
      */
     protected function buildApiUrl($endpoint)
     {
-        return self::API_URL.$this->config->get('token').'/'.$endpoint;
+        return self::API_URL
+            .$this->config->get('token')
+            .($this->config->get('test_environment') ? '/test' : '')
+            .'/'.$endpoint;
     }
 
     /**

--- a/stubs/telegram.php
+++ b/stubs/telegram.php
@@ -12,4 +12,5 @@ return [
     |
     */
     'token' => env('TELEGRAM_TOKEN'),
+    'test_environment' => env('TELEGRAM_TEST_ENVIRONMENT', false),
 ];


### PR DESCRIPTION
By setting a `TELEGRAM_TEST_ENVIRONMENT=true` you can now switch to a Telegram [dedicated test environment](https://core.telegram.org/bots/features#dedicated-test-environment).