### PR TITLE
Input field placeholder support

### DIFF
--- a/src/Extensions/Keyboard.php
+++ b/src/Extensions/Keyboard.php
@@ -14,6 +14,7 @@ class Keyboard
 
     protected $oneTimeKeyboard = false;
     protected $resizeKeyboard = false;
+    protected $inputFieldPlaceholder = '';
 
     /**
      * @var array
@@ -77,6 +78,17 @@ class Keyboard
     }
 
     /**
+     * @param  string  $text
+     * @return $this
+     */
+    public function inputFieldPlaceholder($text)
+    {
+        $this->inputFieldPlaceholder = $text;
+
+        return $this;
+    }
+
+    /**
      * Add a new row to the Keyboard.
      * @param KeyboardButton[] $buttons
      * @return Keyboard
@@ -98,6 +110,7 @@ class Keyboard
                 $this->type => $this->rows,
                 'one_time_keyboard' => $this->oneTimeKeyboard,
                 'resize_keyboard' => $this->resizeKeyboard,
+                'input_field_placeholder' => $this->inputFieldPlaceholder,
             ])->filter()),
         ];
     }


### PR DESCRIPTION
Support of the `input_field_placeholder` keyboard parameter that allows you to set a placeholder into the input field:

```php
$bot->reply('Hi', [
    ...Keyboard::create('keyboard')
        ->addRow(KeyboardButton::create('Button'))
        ->resizeKeyboard()
        ->inputFieldPlaceholder('Hello, world!')
        ->toArray(),
    'parse_mode' => 'HTML',
]);
```

![image](https://github.com/user-attachments/assets/16a01943-6538-462f-b591-47b59b5c8ba2)


https://core.telegram.org/bots/api#replykeyboardmarkup