### PR TITLE
All chat actions support

### DIFF
--- a/src/Extensions/Keyboard.php
+++ b/src/Extensions/Keyboard.php
@@ -14,6 +14,7 @@ class Keyboard
 
     protected $oneTimeKeyboard = false;
     protected $resizeKeyboard = false;
+    protected $inputFieldPlaceholder = '';
 
     /**
      * @var array
@@ -77,6 +78,17 @@ class Keyboard
     }
 
     /**
+     * @param  string  $text
+     * @return $this
+     */
+    public function inputFieldPlaceholder($text)
+    {
+        $this->inputFieldPlaceholder = $text;
+
+        return $this;
+    }
+
+    /**
      * Add a new row to the Keyboard.
      * @param KeyboardButton[] $buttons
      * @return Keyboard
@@ -98,6 +110,7 @@ class Keyboard
                 $this->type => $this->rows,
                 'one_time_keyboard' => $this->oneTimeKeyboard,
                 'resize_keyboard' => $this->resizeKeyboard,
+                'input_field_placeholder' => $this->inputFieldPlaceholder,
             ])->filter()),
         ];
     }

--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -324,6 +324,133 @@ class TelegramDriver extends HttpDriver
     }
 
     /**
+     * @param IncomingMessage $matchingMessage
+     * @return Response
+     */
+    public function uploadsPhoto(IncomingMessage $matchingMessage)
+    {
+        $parameters = [
+            'action' => 'upload_photo',
+        ];
+
+        return $this->sendRequest('sendChatAction', $parameters, $matchingMessage);
+    }
+
+    /**
+     * @param IncomingMessage $matchingMessage
+     * @return Response
+     */
+    public function recordsVideo(IncomingMessage $matchingMessage)
+    {
+        $parameters = [
+            'action' => 'record_video',
+        ];
+
+        return $this->sendRequest('sendChatAction', $parameters, $matchingMessage);
+    }
+
+    /**
+     * @param IncomingMessage $matchingMessage
+     * @return Response
+     */
+    public function uploadsVideo(IncomingMessage $matchingMessage)
+    {
+        $parameters = [
+            'action' => 'upload_video',
+        ];
+
+        return $this->sendRequest('sendChatAction', $parameters, $matchingMessage);
+    }
+
+    /**
+     * @param IncomingMessage $matchingMessage
+     * @return Response
+     */
+    public function recordsVoice(IncomingMessage $matchingMessage)
+    {
+        $parameters = [
+            'action' => 'record_voice',
+        ];
+
+        return $this->sendRequest('sendChatAction', $parameters, $matchingMessage);
+    }
+
+    /**
+     * @param IncomingMessage $matchingMessage
+     * @return Response
+     */
+    public function uploadsVoice(IncomingMessage $matchingMessage)
+    {
+        $parameters = [
+            'action' => 'upload_voice',
+        ];
+
+        return $this->sendRequest('sendChatAction', $parameters, $matchingMessage);
+    }
+
+    /**
+     * @return Response
+     */
+    public function uploadsDocument(IncomingMessage $matchingMessage)
+    {
+        $parameters = [
+            'action' => 'upload_document',
+        ];
+
+        return $this->sendRequest('sendChatAction', $parameters, $matchingMessage);
+    }
+
+    /**
+     * @return Response
+     */
+    public function choosesSticker(IncomingMessage $matchingMessage)
+    {
+        $parameters = [
+            'action' => 'choose_sticker',
+        ];
+
+        return $this->sendRequest('sendChatAction', $parameters, $matchingMessage);
+    }
+
+    /**
+     * @return Response
+     */
+    public function findsLocation(IncomingMessage $matchingMessage)
+    {
+        $parameters = [
+            'action' => 'find_location',
+        ];
+
+        return $this->sendRequest('sendChatAction', $parameters, $matchingMessage);
+    }
+
+    /**
+     * @param IncomingMessage $matchingMessage
+     * @return Response
+     */
+    public function recordsVideoNote(IncomingMessage $matchingMessage)
+    {
+        $parameters = [
+            'action' => 'record_video_note',
+        ];
+
+        return $this->sendRequest('sendChatAction', $parameters, $matchingMessage);
+    }
+
+    /**
+     * @param IncomingMessage $matchingMessage
+     * @return Response
+     */
+    public function uploadsVideoNote(IncomingMessage $matchingMessage)
+    {
+        $parameters = [
+            'action' => 'upload_video_note',
+        ];
+
+        return $this->sendRequest('sendChatAction', $parameters, $matchingMessage);
+    }
+
+    /**
      * Convert a Question object into a valid
      * quick reply response object.
      *


### PR DESCRIPTION
It adds support for more methods in addition to `$bot->types()`:

1. `$bot->uploadsPhoto()`
2. `$bot->recordsVideo()`
3. `$bot->uploadsVideo()`
4. `$bot->recordsVoice()`
5. `$bot->uploadsVoice()`
6. `$bot->uploadsDocument()`
7. `$bot->choosesSticker()`
8. `$bot->findsLocation()`
9. `$bot->recordsVideoNote()`
10. `$bot->uploadsVideoNote()`

https://core.telegram.org/bots/api#sendchataction