### PR TITLE
Added API secret token support

### DIFF
--- a/src/Console/Commands/TelegramRegisterCommand.php
+++ b/src/Console/Commands/TelegramRegisterCommand.php
@@ -36,6 +36,10 @@ class TelegramRegisterCommand extends Command
 
         if (! $remove) {
             $url .= '?url='.$this->ask('What is the target url for the telegram bot?');
+
+            if (config('botman.telegram.api_secret_token')) {
+                $url .= '&secret_token='.config('botman.telegram.api_secret_token');
+            }
         }
 
         $this->info('Using '.$url);

--- a/src/TelegramAudioDriver.php
+++ b/src/TelegramAudioDriver.php
@@ -18,7 +18,9 @@ class TelegramAudioDriver extends TelegramDriver
      */
     public function matchesRequest()
     {
-        return !is_null($this->event->get('from')) && (!is_null($this->event->get('audio')) || !is_null($this->event->get('voice')));
+        return !is_null($this->event->get('from'))
+            && (!is_null($this->event->get('audio')) || !is_null($this->event->get('voice')))
+            && $this->isValidToken();
     }
 
     /**

--- a/src/TelegramContactDriver.php
+++ b/src/TelegramContactDriver.php
@@ -16,7 +16,9 @@ class TelegramContactDriver extends TelegramDriver
      */
     public function matchesRequest()
     {
-        return ! is_null($this->event->get('from')) && ! is_null($this->event->get('contact'));
+        return ! is_null($this->event->get('from'))
+            && ! is_null($this->event->get('contact'))
+            && $this->isValidToken();
     }
 
     /**

--- a/src/TelegramDriver.php
+++ b/src/TelegramDriver.php
@@ -83,6 +83,9 @@ class TelegramDriver extends HttpDriver
     /** @var Collection */
     protected $queryParameters;
 
+    /** @var Request */
+    protected $request;
+
     /**
      * @param Request $request
      */
@@ -105,6 +108,7 @@ class TelegramDriver extends HttpDriver
         $this->event = Collection::make($message);
         $this->config = Collection::make($this->config->get('telegram'));
         $this->queryParameters = Collection::make($request->query);
+        $this->request = $request;
     }
 
     /**
@@ -156,7 +160,8 @@ class TelegramDriver extends HttpDriver
 
         return $noAttachments
             && (! is_null($this->event->get('from')) || ! is_null($this->payload->get('callback_query')) || ! is_null($this->payload->get('pre_checkout_query')))
-            && ! is_null($this->payload->get('update_id'));
+            && ! is_null($this->payload->get('update_id'))
+            && $this->isValidToken();
     }
 
     /**
@@ -181,6 +186,18 @@ class TelegramDriver extends HttpDriver
         }
 
         return $event;
+    }
+
+    /**
+     * Validate the Telegram API secret token.
+     *
+     * @return bool
+     */
+    protected function isValidToken()
+    {
+        $secretToken = $this->config->get('api_secret_token');
+
+        return ! $secretToken || $this->request->headers->get('X-Telegram-Bot-Api-Secret-Token') === $secretToken;
     }
 
     /**

--- a/src/TelegramFileDriver.php
+++ b/src/TelegramFileDriver.php
@@ -18,7 +18,9 @@ class TelegramFileDriver extends TelegramDriver
      */
     public function matchesRequest()
     {
-        return !is_null($this->event->get('from')) && (!is_null($this->event->get('document')));
+        return !is_null($this->event->get('from'))
+            && (!is_null($this->event->get('document')))
+            && $this->isValidToken();
     }
 
     /**

--- a/src/TelegramInlineQueryDriver.php
+++ b/src/TelegramInlineQueryDriver.php
@@ -18,7 +18,8 @@ class TelegramInlineQueryDriver extends TelegramDriver
      */
     public function matchesRequest()
     {
-        return ! is_null($this->payload->get('inline_query'));
+        return ! is_null($this->payload->get('inline_query'))
+            && $this->isValidToken();
     }
 
     /**

--- a/src/TelegramLocationDriver.php
+++ b/src/TelegramLocationDriver.php
@@ -16,7 +16,9 @@ class TelegramLocationDriver extends TelegramDriver
      */
     public function matchesRequest()
     {
-        return ! is_null($this->event->get('from')) && ! is_null($this->event->get('location'));
+        return ! is_null($this->event->get('from'))
+            && ! is_null($this->event->get('location'))
+            && $this->isValidToken();
     }
 
     /**

--- a/src/TelegramPhotoDriver.php
+++ b/src/TelegramPhotoDriver.php
@@ -19,7 +19,9 @@ class TelegramPhotoDriver extends TelegramDriver
      */
     public function matchesRequest()
     {
-        return !is_null($this->event->get('from')) && !is_null($this->event->get('photo'));
+        return !is_null($this->event->get('from'))
+            && !is_null($this->event->get('photo'))
+            && $this->isValidToken();
     }
 
     /**

--- a/src/TelegramVideoDriver.php
+++ b/src/TelegramVideoDriver.php
@@ -18,7 +18,9 @@ class TelegramVideoDriver extends TelegramDriver
      */
     public function matchesRequest()
     {
-        return !is_null($this->event->get('from')) && (!is_null($this->event->get('video')) || !is_null($this->event->get('video_note')));
+        return !is_null($this->event->get('from'))
+            && (!is_null($this->event->get('video')) || !is_null($this->event->get('video_note')))
+            && $this->isValidToken();
     }
 
     /**

--- a/stubs/telegram.php
+++ b/stubs/telegram.php
@@ -12,5 +12,6 @@ return [
     |
     */
     'token' => env('TELEGRAM_TOKEN'),
+    'api_secret_token' => env('TELEGRAM_API_SECRET_TOKEN', null),
     'test_environment' => env('TELEGRAM_TEST_ENVIRONMENT', false),
 ];


### PR DESCRIPTION
The default `/botman` endpoint is not protected from request spoofing. Anybody can talk to your bot pretending to be Telegram. It's a very severe vulnerability. This PR adds protection by a [Telegram API secret token](https://core.telegram.org/bots/api#setwebhook).

1. Set any token in `TELEGRAM_API_SECRET_TOKEN`
2. Update your Telegram webhook using the following command:
```
php artisan botman:telegram:register
```

If `TELEGRAM_API_SECRET_TOKEN` is set this command will automatically set it. Any requests to your `/botman` endpoint without a secret token will be ignored.

@filippotoso, please, merge this and my other PRs. This one is pretty important.