### PR TITLE
Web app inline button type support

### DIFF
--- a/src/Extensions/KeyboardButton.php
+++ b/src/Extensions/KeyboardButton.php
@@ -20,6 +20,11 @@ class KeyboardButton implements \JsonSerializable
     protected $url;
 
     /**
+     * @var array
+     */
+    protected $webApp;
+
+    /**
      * @var string
      */
     protected $callbackData;
@@ -69,6 +74,18 @@ class KeyboardButton implements \JsonSerializable
     public function url($url)
     {
         $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function webApp($url)
+    {
+        $this->webApp = [
+            'url' => $url,
+        ];
 
         return $this;
     }
@@ -140,6 +157,7 @@ class KeyboardButton implements \JsonSerializable
     {
         return Collection::make([
             'url' => $this->url,
+            'web_app' => $this->webApp,
             'callback_data' => $this->callbackData,
             'switch_inline_query' => $this->switchInlineQuery,
             'switch_inline_query_current_chat' => $this->switchInlineQueryCurrentChat,


### PR DESCRIPTION
An inline button may have a type of `web_app` (https://core.telegram.org/bots/api#inlinekeyboardbutton). This PR makes it possible to create such buttons:

```php
KeyboardButton::create('Start')->webApp('https://yourwebapp.url')
```